### PR TITLE
Increase the default LimitRequestLine to 20000

### DIFF
--- a/haproxy-wi.conf
+++ b/haproxy-wi.conf
@@ -2,7 +2,8 @@
         ServerName haproxy-wi
         ErrorLog /var/log/httpd/haproxy-wi.error.log
         CustomLog /var/log/httpd/haproxy-wi.access.log combined
-		TimeOut 600
+        TimeOut 600
+        LimitRequestLine 20000
         DocumentRoot /var/www/haproxy-wi
         ScriptAlias /cgi-bin/ "/var/www/haproxy-wi/app/"
 


### PR DESCRIPTION
We are getting 414 “Request URI too long” errors when making changes to big configuration files.

This increases that limit to 20000 bytes